### PR TITLE
Add imix support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ flash-bootloader: $(OUTPUT_FILE_PATH)
 	$(JLINK) $(JLINK_OPTIONS) flash-bootloader.jlink
 
 hail: all
+imix: all
 justjump: all
 
 # Other Targets

--- a/src/bootloader_board.h
+++ b/src/bootloader_board.h
@@ -16,6 +16,22 @@
 #define ATTRIBUTES_02_LEN 19
 #define ATTRIBUTES_02_DEF {'j','l','d','e','v','i','c','e',10,'A','T','S','A','M','4','L','C','8','C'}
 
+#elif TOCK_BOARD_imix == 1
+#define BOOTLOADER_SELECT_PIN PIN_PB06
+
+#define BOOTLOADER_UART_TX_PIN PIN_PB10A_USART3_TXD
+#define BOOTLOADER_UART_TX_MUX MUX_PB10A_USART3_TXD
+#define BOOTLOADER_UART_RX_PIN PIN_PB09A_USART3_RXD
+#define BOOTLOADER_UART_RX_MUX MUX_PB09A_USART3_RXD
+#define BOOTLOADER_UART USART3
+
+#define ATTRIBUTES_00_LEN 13
+#define ATTRIBUTES_00_DEF {'b','o','a','r','d','\0','\0','\0',4,'i','m','i','x'}
+#define ATTRIBUTES_01_LEN 18
+#define ATTRIBUTES_01_DEF {'a','r','c','h','\0','\0','\0','\0',9,'c','o','r','t','e','x','-','m','4'}
+#define ATTRIBUTES_02_LEN 19
+#define ATTRIBUTES_02_DEF {'j','l','d','e','v','i','c','e',10,'A','T','S','A','M','4','L','C','8','C'}
+
 #elif TOCK_BOARD_justjump == 1
 
 // unused, but defined for compilation


### PR DESCRIPTION
Added hardcoded attributes and pin configurations for imix. Tested successfully on an imix v1.3 and the latest tockloader from pip.