### PR TITLE
Tie to release-1.3 kernel + small nits

### DIFF
--- a/boards/hail-bootloader/Cargo.lock
+++ b/boards/hail-bootloader/Cargo.lock
@@ -2,7 +2,7 @@
 name = "bootloader"
 version = "0.1.0"
 dependencies = [
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
  "tockloader-proto 0.2.1 (git+https://github.com/tock/tockloader-proto-rs)",
 ]
 
@@ -18,33 +18,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "capsules"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#ede88f41c8e7073d6115272d52f574526ce4ed9a"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "enum_primitive 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "enum_primitive 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "cortexm"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#ede88f41c8e7073d6115272d52f574526ce4ed9a"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "cortexm4"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#ede88f41c8e7073d6115272d52f574526ce4ed9a"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "cortexm 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "cortexm 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "enum_primitive"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#ede88f41c8e7073d6115272d52f574526ce4ed9a"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 
 [[package]]
 name = "hailbootloader"
@@ -52,39 +52,39 @@ version = "0.1.0"
 dependencies = [
  "bootloader 0.1.0",
  "bootloader_attributes 0.1.0",
- "capsules 0.1.0 (git+https://github.com/tock/tock)",
- "cortexm4 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
- "sam4l 0.1.0 (git+https://github.com/tock/tock)",
+ "capsules 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "cortexm4 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "sam4l 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "kernel"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#ede88f41c8e7073d6115272d52f574526ce4ed9a"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "tock-cells 0.1.0 (git+https://github.com/tock/tock)",
- "tock-registers 0.2.0 (git+https://github.com/tock/tock)",
+ "tock-cells 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "tock-registers 0.2.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "sam4l"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#ede88f41c8e7073d6115272d52f574526ce4ed9a"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "cortexm4 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "cortexm4 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "tock-cells"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#ede88f41c8e7073d6115272d52f574526ce4ed9a"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 
 [[package]]
 name = "tock-registers"
 version = "0.2.0"
-source = "git+https://github.com/tock/tock#ede88f41c8e7073d6115272d52f574526ce4ed9a"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 
 [[package]]
 name = "tockloader-proto"
@@ -96,12 +96,12 @@ dependencies = [
 
 [metadata]
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
-"checksum capsules 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum cortexm 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum cortexm4 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum enum_primitive 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum kernel 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum sam4l 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum tock-cells 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum tock-registers 0.2.0 (git+https://github.com/tock/tock)" = "<none>"
+"checksum capsules 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum cortexm 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum cortexm4 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum enum_primitive 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum sam4l 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum tock-cells 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum tock-registers 0.2.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
 "checksum tockloader-proto 0.2.1 (git+https://github.com/tock/tockloader-proto-rs)" = "<none>"

--- a/boards/hail-bootloader/Cargo.toml
+++ b/boards/hail-bootloader/Cargo.toml
@@ -15,10 +15,10 @@ panic = "abort"
 lto = true
 
 [dependencies]
-cortexm4 = { git = "https://github.com/tock/tock" }
-capsules = { git = "https://github.com/tock/tock" }
-kernel = { git = "https://github.com/tock/tock" }
-sam4l = { git = "https://github.com/tock/tock" }
+cortexm4 = { git = "https://github.com/tock/tock", tag = "release-1.3"  }
+capsules = { git = "https://github.com/tock/tock", tag = "release-1.3"  }
+kernel = { git = "https://github.com/tock/tock", tag = "release-1.3"  }
+sam4l = { git = "https://github.com/tock/tock", tag = "release-1.3"  }
 bootloader = { path = "../../bootloader" }
 
 [build-dependencies]

--- a/boards/hail-bootloader/src/main.rs
+++ b/boards/hail-bootloader/src/main.rs
@@ -38,14 +38,12 @@ struct HailBootloader {
 }
 
 impl Platform for HailBootloader {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, _driver_num: usize, f: F) -> R
     where
         F: FnOnce(Option<&kernel::Driver>) -> R,
     {
         // Bootloader does not support apps.
-        match driver_num {
-            _ => f(None),
-        }
+        f(None)
     }
 }
 

--- a/boards/imix-bootloader/Cargo.lock
+++ b/boards/imix-bootloader/Cargo.lock
@@ -2,7 +2,7 @@
 name = "bootloader"
 version = "0.1.0"
 dependencies = [
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
  "tockloader-proto 0.2.1 (git+https://github.com/tock/tockloader-proto-rs)",
 ]
 
@@ -18,33 +18,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "capsules"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#7f31ad53384ce16c922364715d94aff5767ef0c6"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "enum_primitive 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "enum_primitive 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "cortexm"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#7f31ad53384ce16c922364715d94aff5767ef0c6"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "cortexm4"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#7f31ad53384ce16c922364715d94aff5767ef0c6"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "cortexm 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "cortexm 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "enum_primitive"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#7f31ad53384ce16c922364715d94aff5767ef0c6"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 
 [[package]]
 name = "imixbootloader"
@@ -52,39 +52,39 @@ version = "0.1.0"
 dependencies = [
  "bootloader 0.1.0",
  "bootloader_attributes 0.1.0",
- "capsules 0.1.0 (git+https://github.com/tock/tock)",
- "cortexm4 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
- "sam4l 0.1.0 (git+https://github.com/tock/tock)",
+ "capsules 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "cortexm4 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "sam4l 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "kernel"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#7f31ad53384ce16c922364715d94aff5767ef0c6"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "tock-cells 0.1.0 (git+https://github.com/tock/tock)",
- "tock-registers 0.2.0 (git+https://github.com/tock/tock)",
+ "tock-cells 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "tock-registers 0.2.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "sam4l"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#7f31ad53384ce16c922364715d94aff5767ef0c6"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "cortexm4 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "cortexm4 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "tock-cells"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#7f31ad53384ce16c922364715d94aff5767ef0c6"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 
 [[package]]
 name = "tock-registers"
 version = "0.2.0"
-source = "git+https://github.com/tock/tock#7f31ad53384ce16c922364715d94aff5767ef0c6"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 
 [[package]]
 name = "tockloader-proto"
@@ -96,12 +96,12 @@ dependencies = [
 
 [metadata]
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
-"checksum capsules 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum cortexm 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum cortexm4 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum enum_primitive 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum kernel 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum sam4l 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum tock-cells 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum tock-registers 0.2.0 (git+https://github.com/tock/tock)" = "<none>"
+"checksum capsules 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum cortexm 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum cortexm4 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum enum_primitive 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum sam4l 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum tock-cells 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum tock-registers 0.2.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
 "checksum tockloader-proto 0.2.1 (git+https://github.com/tock/tockloader-proto-rs)" = "<none>"

--- a/boards/imix-bootloader/Cargo.toml
+++ b/boards/imix-bootloader/Cargo.toml
@@ -15,10 +15,10 @@ panic = "abort"
 lto = true
 
 [dependencies]
-cortexm4 = { git = "https://github.com/tock/tock" }
-capsules = { git = "https://github.com/tock/tock" }
-kernel = { git = "https://github.com/tock/tock" }
-sam4l = { git = "https://github.com/tock/tock" }
+cortexm4 = { git = "https://github.com/tock/tock", tag = "release-1.3" }
+capsules = { git = "https://github.com/tock/tock", tag = "release-1.3"  }
+kernel = { git = "https://github.com/tock/tock", tag = "release-1.3"  }
+sam4l = { git = "https://github.com/tock/tock", tag = "release-1.3"  }
 bootloader = { path = "../../bootloader" }
 
 [build-dependencies]

--- a/boards/imix-bootloader/src/main.rs
+++ b/boards/imix-bootloader/src/main.rs
@@ -38,14 +38,12 @@ struct ImixBootloader {
 }
 
 impl Platform for ImixBootloader {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, _driver_num: usize, f: F) -> R
     where
         F: FnOnce(Option<&kernel::Driver>) -> R,
     {
         // Bootloader does not support apps.
-        match driver_num {
-            _ => f(None),
-        }
+        f(None)
     }
 }
 

--- a/boards/nrf52-bootloader/Cargo.lock
+++ b/boards/nrf52-bootloader/Cargo.lock
@@ -2,7 +2,7 @@
 name = "bootloader"
 version = "0.1.0"
 dependencies = [
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
  "tockloader-proto 0.2.1 (git+https://github.com/tock/tockloader-proto-rs)",
 ]
 
@@ -18,51 +18,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "capsules"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#616cb87ef9ea1829fd7ce2d222a218371090e8fc"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "enum_primitive 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "enum_primitive 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "cortexm"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#616cb87ef9ea1829fd7ce2d222a218371090e8fc"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "cortexm4"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#616cb87ef9ea1829fd7ce2d222a218371090e8fc"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "cortexm 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "cortexm 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "enum_primitive"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#616cb87ef9ea1829fd7ce2d222a218371090e8fc"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 
 [[package]]
 name = "kernel"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#616cb87ef9ea1829fd7ce2d222a218371090e8fc"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "tock-cells 0.1.0 (git+https://github.com/tock/tock)",
- "tock-registers 0.2.0 (git+https://github.com/tock/tock)",
+ "tock-cells 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "tock-registers 0.2.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "nrf52"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#616cb87ef9ea1829fd7ce2d222a218371090e8fc"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "cortexm4 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
- "nrf5x 0.1.0 (git+https://github.com/tock/tock)",
+ "cortexm4 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "nrf5x 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
@@ -71,30 +71,30 @@ version = "0.1.0"
 dependencies = [
  "bootloader 0.1.0",
  "bootloader_attributes 0.1.0",
- "capsules 0.1.0 (git+https://github.com/tock/tock)",
- "cortexm4 0.1.0 (git+https://github.com/tock/tock)",
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
- "nrf52 0.1.0 (git+https://github.com/tock/tock)",
- "nrf5x 0.1.0 (git+https://github.com/tock/tock)",
+ "capsules 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "cortexm4 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "nrf52 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
+ "nrf5x 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "nrf5x"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#616cb87ef9ea1829fd7ce2d222a218371090e8fc"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 dependencies = [
- "kernel 0.1.0 (git+https://github.com/tock/tock)",
+ "kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)",
 ]
 
 [[package]]
 name = "tock-cells"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock#616cb87ef9ea1829fd7ce2d222a218371090e8fc"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 
 [[package]]
 name = "tock-registers"
 version = "0.2.0"
-source = "git+https://github.com/tock/tock#616cb87ef9ea1829fd7ce2d222a218371090e8fc"
+source = "git+https://github.com/tock/tock?tag=release-1.3#9743146e18f45b7636ba9b9687b28937d6e9f261"
 
 [[package]]
 name = "tockloader-proto"
@@ -106,13 +106,13 @@ dependencies = [
 
 [metadata]
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
-"checksum capsules 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum cortexm 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum cortexm4 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum enum_primitive 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum kernel 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum nrf52 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum nrf5x 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum tock-cells 0.1.0 (git+https://github.com/tock/tock)" = "<none>"
-"checksum tock-registers 0.2.0 (git+https://github.com/tock/tock)" = "<none>"
+"checksum capsules 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum cortexm 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum cortexm4 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum enum_primitive 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum kernel 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum nrf52 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum nrf5x 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum tock-cells 0.1.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
+"checksum tock-registers 0.2.0 (git+https://github.com/tock/tock?tag=release-1.3)" = "<none>"
 "checksum tockloader-proto 0.2.1 (git+https://github.com/tock/tockloader-proto-rs)" = "<none>"

--- a/boards/nrf52-bootloader/Cargo.toml
+++ b/boards/nrf52-bootloader/Cargo.toml
@@ -17,11 +17,11 @@ opt-level = "z"
 debug = true
 
 [dependencies]
-cortexm4 = { git = "https://github.com/tock/tock" }
-capsules = { git = "https://github.com/tock/tock" }
-kernel = { git = "https://github.com/tock/tock" }
-nrf52 = { git = "https://github.com/tock/tock" }
-nrf5x = { git = "https://github.com/tock/tock" }
+cortexm4 = { git = "https://github.com/tock/tock", tag = "release-1.3" }
+capsules = { git = "https://github.com/tock/tock", tag = "release-1.3" }
+kernel = { git = "https://github.com/tock/tock", tag = "release-1.3" }
+nrf52 = { git = "https://github.com/tock/tock", tag = "release-1.3" }
+nrf5x = { git = "https://github.com/tock/tock", tag = "release-1.3" }
 bootloader = { path = "../../bootloader" }
 
 [build-dependencies]

--- a/boards/nrf52-bootloader/src/main.rs
+++ b/boards/nrf52-bootloader/src/main.rs
@@ -66,13 +66,11 @@ pub struct Nrf52Bootloader {
 }
 
 impl kernel::Platform for Nrf52Bootloader {
-    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    fn with_driver<F, R>(&self, _driver_num: usize, f: F) -> R
     where
         F: FnOnce(Option<&kernel::Driver>) -> R,
     {
-        match driver_num {
-            _ => f(None),
-        }
+        f(None)
     }
 }
 

--- a/bootloader/Cargo.toml
+++ b/bootloader/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 
 [dependencies]
-kernel = { git = "https://github.com/tock/tock" }
+kernel = { git = "https://github.com/tock/tock", tag = "release-1.3" }
 tockloader-proto = { git = "https://github.com/tock/tockloader-proto-rs" }

--- a/bootloader/src/uart_receive_timeout.rs
+++ b/bootloader/src/uart_receive_timeout.rs
@@ -86,7 +86,7 @@ impl<'a, A: hil::time::Alarm> hil::uart::UART for UartReceiveTimeout<'a, A> {
 }
 
 impl<'a, A: hil::time::Alarm> hil::uart::UARTReceiveAdvanced for UartReceiveTimeout<'a, A> {
-    fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8) {
+    fn receive_automatic(&self, rx_buffer: &'static mut [u8], _interbyte_timeout: u8) {
         // Just call receive with the entire buffer.
         let len = rx_buffer.len();
         self.uart.receive(rx_buffer, len);


### PR DESCRIPTION
The PR specifies that each of the bootloaders should use, specifically, release tag `release-1.3` of the Tock git repo.

It also makes a couple small stylistic changes to get rid of warnings and remove a small bit of redundant code.