### PR TITLE
Microbit v2 serial bootloader release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Micro:bit v2 Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+
+jobs:
+  release:
+    runs-on: "ubuntu-latest"
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1 # pulls version from rust-toolchain file
+      - name: build bootloader
+        run: |
+          cd boards/microbit_v2-bootloader
+          export BOOTLOADER_VERSION="${{ github.event.inputs.version }}"
+          export BOOTLOADER_HASH="$(git rev-parse HEAD)"
+          export BOOTLOADER_KERNEL_HASH="$(cat Cargo.lock | grep https://github.com/tock/tock?branch=remove-submodule | uniq | cut -d '#' -f 2 | cut -d '"' -f 1)"
+          make
+      - name: Version
+        run: |
+          echo "Version: ${{ github.event.inputs.version }}" > tock-bootloader.microbit_v2.version
+          echo "Toolchain: $(rustc --version)" >> tock-bootloader.microbit_v2.version
+          echo "Tock Bootloader Hash: $(git rev-parse HEAD)" >> tock-bootloader.microbit_v2.version
+          echo Tock Hash: $(cat boards/microbit_v2-bootloader/Cargo.lock | grep https://github.com/tock/tock?branch=remove-submodule | uniq |  cut -d '#' -f 2 | cut -d '"' -f 1) >> tock-bootloader.microbit_v2.version
+          echo "Bootloader SHA256: $(sha256sum target/thumbv7em-none-eabi/release/microbit_v2-bootloader.bin | cut -d ' ' -f 1)" >> tock-bootloader.microbit_v2.version
+          echo "Build Date: $(date)" >> tock-bootloader.microbit_v2.version
+      - name: Upload bootloader release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          release_name: Micro:bit v2 ${{ github.event.inputs.version }}
+          prerelease: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/thumbv7em-none-eabi/release/microbit_v2-bootloader.bin
+          asset_name: tock-bootloader.microbit_v2.v${{ github.event.inputs.version }}.bin
+          tag: microbit_v2-v${{ github.event.inputs.version }}
+          overwrite: true
+          body: "Bootloader for Micro:bit v2 v${{ github.event.inputs.version }}"
+      - name: Upload bootloader version
+        uses: svenstaro/upload-release-action@v2
+        with:
+          release_name: Micro:bit v2 ${{ github.event.inputs.version }}
+          prerelease: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: tock-bootloader.microbit_v2.version
+          asset_name: tock-bootloader.microbit_v2.v${{ github.event.inputs.version }}.version
+          tag: microbit_v2-v${{ github.event.inputs.version }}

--- a/boards/microbit_v2-bootloader/Cargo.lock
+++ b/boards/microbit_v2-bootloader/Cargo.lock
@@ -39,16 +39,17 @@ checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 [[package]]
 name = "capsules"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 dependencies = [
  "enum_primitive",
  "kernel",
+ "tickv",
 ]
 
 [[package]]
 name = "components"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 dependencies = [
  "capsules",
  "kernel",
@@ -57,7 +58,7 @@ dependencies = [
 [[package]]
 name = "cortexm"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 dependencies = [
  "kernel",
 ]
@@ -65,7 +66,7 @@ dependencies = [
 [[package]]
 name = "cortexm4"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 dependencies = [
  "cortexm",
  "kernel",
@@ -74,12 +75,12 @@ dependencies = [
 [[package]]
 name = "enum_primitive"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 
 [[package]]
 name = "kernel"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 dependencies = [
  "tock-cells",
  "tock-registers",
@@ -105,7 +106,7 @@ dependencies = [
 [[package]]
 name = "nrf52"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 dependencies = [
  "cortexm4",
  "enum_primitive",
@@ -117,7 +118,7 @@ dependencies = [
 [[package]]
 name = "nrf52833"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 dependencies = [
  "cortexm4",
  "kernel",
@@ -128,11 +129,16 @@ dependencies = [
 [[package]]
 name = "nrf5x"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 dependencies = [
  "enum_primitive",
  "kernel",
 ]
+
+[[package]]
+name = "tickv"
+version = "0.1.0"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 
 [[package]]
 name = "tock-bootloader-protocol"
@@ -144,19 +150,19 @@ dependencies = [
 [[package]]
 name = "tock-cells"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 
 [[package]]
 name = "tock-registers"
 version = "0.6.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 
 [[package]]
 name = "tock-rt0"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"
 
 [[package]]
 name = "tock-tbf"
 version = "0.1.0"
-source = "git+https://github.com/tock/tock?branch=master#af1efe87f3f52f9dc923f0ca936091f7681ce59a"
+source = "git+https://github.com/tock/tock?branch=master#e5c422ba232a7e4287b7b72ce5d85e8c41cf6e62"

--- a/boards/microbit_v2-bootloader/build.rs
+++ b/boards/microbit_v2-bootloader/build.rs
@@ -1,12 +1,24 @@
 extern crate bootloader_attributes;
+use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rerun-if-changed=../kernel_layout.ld");
 
     let mut f = bootloader_attributes::get_file();
-    bootloader_attributes::write_flags(&mut f, "1.1.1", 0x8000);
+    let version = if let Ok(v) = env::var("BOOTLOADER_VERSION") {
+        v
+    } else {
+        String::from("1.1.1")
+    };
+    bootloader_attributes::write_flags(&mut f, &version, 0x8000);
     bootloader_attributes::write_attribute(&mut f, "board", "microbit_v2");
     bootloader_attributes::write_attribute(&mut f, "arch", "cortex-m4");
     bootloader_attributes::write_attribute(&mut f, "appaddr", "0x40000");
+    if let Ok(bootloader) = env::var("BOOTLOADER_HASH") {
+        bootloader_attributes::write_attribute(&mut f, "boothash", &bootloader);
+    }
+    if let Ok(bootloader_kernel) = env::var("BOOTLOADER_KERNEL_HASH") {
+        bootloader_attributes::write_attribute(&mut f, "kernhash", &bootloader_kernel);
+    }
 }


### PR DESCRIPTION
This PR adds a release workflow to generate a bootloader bin and version file and upload them to a github release.

The workflow is manually activated and asks for the bootloader version as a parameter.

I had to use the "development" dependencies as otherwise cargo clones the tock repository recursively (due to qemu) and the workflow throws a network error.

This PR is a followup for #21 