### PR TITLE
microbit_v2: fixed openocd flashing script

### DIFF
--- a/boards/microbit_v2-bootloader/Makefile
+++ b/boards/microbit_v2-bootloader/Makefile
@@ -15,8 +15,8 @@ OPENOCD_OPTIONS=-f openocd.cfg
 # Upload the kernel over JTAG
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $<; verify_image $<; reset; shutdown;"
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $<; verify_image $<; reset halt; shutdown;"
 
 .PHONY: flash
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $<; verify_image $<; reset; shutdown;"
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $<; verify_image $<; reset halt; shutdown;"

--- a/boards/microbit_v2-bootloader/openocd.cfg
+++ b/boards/microbit_v2-bootloader/openocd.cfg
@@ -2,10 +2,11 @@ source [find interface/cmsis-dap.cfg]
 transport select swd
 source [find target/nrf52.cfg]
 
-set WORKAREASIZE 0x40000
+# necessary to be backward compatible with openocd 0.10
+if { [flash list] == "" } {
+    set WORKAREASIZE 0x40000
+    $_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $WORKAREASIZE -work-area-backup 0
 
-$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $WORKAREASIZE -work-area-backup 0
-
-flash bank $_CHIPNAME.flash nrf51 0x00000000 0 1 1 $_TARGETNAME
-flash bank $_CHIPNAME.uicr nrf51 0x10001000 0 1 1 $_TARGETNAME
-
+    flash bank $_CHIPNAME.flash nrf51 0x00000000 0 1 1 $_TARGETNAME
+    flash bank $_CHIPNAME.uicr nrf51 0x10001000 0 1 1 $_TARGETNAME
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes seemingly transient errors which occurred when trying to either the bootloader or the kernel on the microbit_v2 board. **There is also a pull request on the same topic on the `tock` [repository](https://github.com/tock/tock/pull/3226)**

Because the openocd script tried to be backwards compatible to v0.10, it copied some of the configs that were added in v0.11. This resulted in errors like: `flash bank already exists` mentioned on this [ticket](https://sourceforge.net/p/openocd/tickets/356/).

Changing `reset` to `reset halt` in the Makefile was needed to avoid another error: `clearing lockup after double fault`. 

### Testing Strategy

This pull request was tested by trying combinations of removing my default user from the `dialout` and `plugdev` groups and commenting the openocd `udev` rules for CMSIS-DAP compatible adapters.