### PR TITLE
added llvm-tools rust component check in Common.mk

### DIFF
--- a/boards/Common.mk
+++ b/boards/Common.mk
@@ -192,7 +192,6 @@ ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (
   $(warning Consider updating 'targets' in 'rust-toolchain.toml')
   $(shell sleep 5s && $(RUSTUP) target add $(TARGET))
 endif
-endif # $(NO_RUSTUP)
 # check llvm_tools component
 LLVM_TOOLS_INSTALLED := $(shell  rustup component list --installed | grep llvm-tools 1>/dev/null 2>&1 && echo "true" || echo "no")
 ifeq ($(LLVM_TOOLS_INSTALLED), true)
@@ -202,6 +201,7 @@ else
     $(warning Install llvm-tools component: rustup component add llvm-tools , and try again.)
     TOOLCHAIN := N/A
 endif
+endif # $(NO_RUSTUP)
 
 # If the user is using the standard toolchain provided as part of the llvm-tools
 # rustup component we need to get the full path. rustup should take care of this

--- a/boards/Common.mk
+++ b/boards/Common.mk
@@ -193,6 +193,15 @@ ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (
   $(shell sleep 5s && $(RUSTUP) target add $(TARGET))
 endif
 endif # $(NO_RUSTUP)
+# check llvm_tools component
+LLVM_TOOLS_INSTALLED := $(shell  rustup component list --installed | grep llvm-tools 1>/dev/null 2>&1 && echo "true" || echo "no")
+ifeq ($(LLVM_TOOLS_INSTALLED), true)
+    $(info llvm-tools component seems to be installed, continue...)
+    TOOLCHAIN := llvm-tools
+else
+    $(warning Install llvm-tools component: rustup component add llvm-tools , and try again.)
+    TOOLCHAIN := N/A
+endif
 
 # If the user is using the standard toolchain provided as part of the llvm-tools
 # rustup component we need to get the full path. rustup should take care of this


### PR DESCRIPTION
Hi!

I was using official docs and I was stuck compiling the bootloader for the Arduino Nano33BLE at this step 

![Captura desde 2024-02-07 12-59-07](https://github.com/tock/tock-bootloader/assets/10772286/0a7666e2-22f4-446d-a152-197e4ce19742)

After some tests I've found I had no llvm-tools rust component installed, I added it by:
```
rustup component add llvm-tools
```
And now it works

I've added some check for it with info about installing component in the Makefile I think is useful

Cheers!

